### PR TITLE
Fixed Fetcher example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,8 +81,7 @@ $fetcher = new Fetcher(
 );
 
 // Fetch the actual data.
-$fetcher->fetchBaseData();
-$data = $fetcher->getBaseData();
+$data = $fetcher->fetchBaseData();
 ```
 
 Integrations

--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,8 @@ $fetcher = new Fetcher(
 );
 
 // Fetch the actual data.
-$data = $fetcher->fetchBaseData();
+$fetcher->fetchBaseData();
+$data = $fetcher->getBaseData();
 ```
 
 Integrations

--- a/src/Model/FetcherBase.php
+++ b/src/Model/FetcherBase.php
@@ -205,7 +205,7 @@ abstract class FetcherBase implements FetcherInterface
      * @param \GuzzleHttp\Handler\MockHandler|null $handler
      *   Used for testing, the mockHandler is used for emulating web requests.
      *
-     * @return void
+     * @return SimpleXML-Object
      * @throws InvalidDataSheetException
      */
     public function fetchBaseData(MockHandler $handler = null)
@@ -229,7 +229,7 @@ abstract class FetcherBase implements FetcherInterface
 
                 if ($this->icecatXmlHasValidData($xml)) {
                     $this->setBaseData($xml);
-                    break;
+                    return this->getBaseData();
                 }
             }
             $this->handleInvalidRequestError($icecatRequestResult);

--- a/src/Model/FetcherBase.php
+++ b/src/Model/FetcherBase.php
@@ -229,7 +229,7 @@ abstract class FetcherBase implements FetcherInterface
 
                 if ($this->icecatXmlHasValidData($xml)) {
                     $this->setBaseData($xml);
-                    return this->getBaseData();
+                    return $this->getBaseData();
                 }
             }
             $this->handleInvalidRequestError($icecatRequestResult);


### PR DESCRIPTION
The Fetcher example was not working.
$fetcher->fetchBaseData(); doesn't return any data.
The actual data has to be retrieved with $fetcher->getBaseData(); after the data has been fetched from Icecat