### PR TITLE
ProductDescription is not always present

### DIFF
--- a/src/Model/Result.php
+++ b/src/Model/Result.php
@@ -87,7 +87,11 @@ class Result implements ResultInterface
      */
     public function getLongDescription()
     {
-        return $this->getProductData()->ProductDescription->{'@attributes'}->LongDesc;
+        if (!empty($this->getProductData()->ProductDescription->{'@attributes'})) {
+            return $this->getProductData()->ProductDescription->{'@attributes'}->LongDesc;
+        } else {
+            return '';
+        }
     }
 
     /**
@@ -97,7 +101,11 @@ class Result implements ResultInterface
      */
     public function getShortDescription()
     {
-        return $this->getProductData()->ProductDescription->{'@attributes'}->ShortDesc;
+        if (!empty($this->getProductData()->ProductDescription->{'@attributes'})) {
+            return $this->getProductData()->ProductDescription->{'@attributes'}->ShortDesc;
+        } else {
+            return '';
+        }
     }
 
     /**


### PR DESCRIPTION
Sometimes the productDescription is not present, resulting in an error message `Undefined property: stdClass::$@attributes`.
This fix checkes for the existence of the @attributes property. 
Returns an empty string is property does nog exists.