### PR TITLE
productHasImageGallery() should check on ProductPicture property

### DIFF
--- a/src/Model/Result.php
+++ b/src/Model/Result.php
@@ -153,7 +153,7 @@ class Result implements ResultInterface
      */
     private function productHasImageGallery()
     {
-        return !empty($this->getProductData()->ProductGallery);
+        return !empty($this->getProductData()->ProductGallery->ProductPicture);
     }
 
     private function productHasMainImage()


### PR DESCRIPTION
Sometimes $this->getProductData()->ProductGallery has no property ProductPicture, which results in an error.
This PR solves this